### PR TITLE
Also Windows needs to indlude the unistd header

### DIFF
--- a/devtools/patchserver/netio.cpp
+++ b/devtools/patchserver/netio.cpp
@@ -27,7 +27,6 @@
 #ifdef WINDOWS
 #include <winsock.h>
 #else
-#include <unistd.h>
 #include <sys/socket.h>
 #include <netinet/tcp.h>
 #include <netinet/in.h>
@@ -38,6 +37,7 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <string.h>
+#include <unistd.h>
 
 #include "commandline.h"
  


### PR DESCRIPTION
Under Cygwin (I tested it also under mingw) we need to include also the unistd header file to use functions such as read() write() etc... Otherwise the compilation does NOT work. The header file should be available on both win (w/ cygwin/mingw) and linux 
