### PR TITLE
sleep() (lower case) could be unavailable on windows OS

### DIFF
--- a/devtools/patchserver/webserver.cpp
+++ b/devtools/patchserver/webserver.cpp
@@ -153,7 +153,11 @@ int webserver_command(int weblistener) {
 							
 						/* wait for buffers to empty */
 						// FIXME - shouldn't need a sleep
+#ifdef WINDOWS
+						Sleep(2);
+#else
 						sleep(2);
+#endif
 						printf("OK") ;
 					}
 				}


### PR DESCRIPTION
It is possible that the lower case sleep() function is NOT available under Windows, this may not be the case when using the newest version of cygwin/mingw, but this fix should fix unecessary problems
