### PR TITLE
Fixes the URL to the server which provides the up-to-date patchlist file

### DIFF
--- a/devtools/patchserver/patchfiles.lst
+++ b/devtools/patchserver/patchfiles.lst
@@ -1,2 +1,1 @@
-sharpfin.zevv.nl http://sharpfin.zevv.nl/websvn/filedetails.php?repname=Sharpfin&path=%2Fconfig%2Fpatchfiles.lst 80
-
+www.pschmidt.it /sharpfin/patchfiles.lst 80


### PR DESCRIPTION
Use pschmidt.it as the default server that provides an up-to-date list of patch files to use with the Sharpfin patchserver.
The URL:
http://www.pschmidt.it/sharpfin/patchfiles.lst
should return a list of all patchfiles available provided by the Sharpfin project
