### PR TITLE
Makefile update for recent changes

### DIFF
--- a/devtools/patchserver/Makefile
+++ b/devtools/patchserver/Makefile
@@ -1,9 +1,20 @@
-# 
+# Sharpfin project
+# Copyright (C) by Steve Clarke and Ico Doornekamp
+# 2011-11-30 Philipp Schmidt
+#   Added to github
+#
+# This file is part of the sharpfin project
+#
+# This Library is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
 # This Library is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-#  
+#
 # You should have received a copy of the GNU General Public License
 # along with this source files. If not, see
 # <http://www.gnu.org/licenses/>.


### PR DESCRIPTION
This Pull Request updates the Makefile s.t. we can build it with:
- linux: make linux
- win:  make windoze
- (try) both: make (e.g. under cygwin)

It creates also the tar.bz2 (linux) and zip (windows) patch archives and auto-generates the PDF file (unoconv or soffice)
