### PR TITLE
This Makefile should habe absolute lib/include path

### DIFF
--- a/src/apps/lcdtest/Makefile
+++ b/src/apps/lcdtest/Makefile
@@ -21,8 +21,8 @@
 
 BIN   	  := lcdtest
 SRC 	  := lcdtest.c
-CFLAGS    += -I../../libreciva/include
-LDFLAGS   += -L../../libreciva -lreciva
+CFLAGS    += -I$(PWD)/../../libreciva/include
+LDFLAGS   += -L$(PWD)/../../libreciva -lreciva
 VER	:=	"`cat debug/revision.txt | cut -d' ' -f2`"
 
 include ../../Rules.mak


### PR DESCRIPTION
The lcdtest will e.g. be used also as a test patch for the patchserver, therefore this Makefile should be "buildable" directly and hence the -L flags should be absolute
