### PR TITLE
make libreciva bundle fix

### DIFF
--- a/src/make-libreciva-bundle
+++ b/src/make-libreciva-bundle
@@ -26,5 +26,5 @@ REV="`cat libreciva/README | grep '$Revision' | cut -d' ' -f2`"
 (cd libreciva ; make clean )
 find libreciva -name "*~" -exec /bin/rm -f {} \;
 find libreciva -name "~*" -exec /bin/rm -f {} \;
-tar cf libreciva-src-$REV.tar --exclude .svn LICENSE Rules.mak libreciva include
+tar cfh libreciva-src-$REV.tar --exclude .git LICENSE Rules.mak libreciva include/reciva
 bzip2 libreciva-src-$REV.tar


### PR DESCRIPTION
Fixes the generation of the libreciva bundle, excludes git and follow symbolic link to reciva headers
