### PR TITLE
sharpfin ftpd links fixed

### DIFF
--- a/src/ipk/sharpfin-ftpd-ipk/files/CONTROL/control
+++ b/src/ipk/sharpfin-ftpd-ipk/files/CONTROL/control
@@ -2,8 +2,8 @@ Package: sharpfin-ftpd
 Priority: optional
 Version:  0.1
 Architecture: arm
-Maintainer: Sharpfin Project (http://www.sharpfin.zevv.nl/)
-Source: http://www.sharpfin.zevv.nl/gpl
+Maintainer: Sharpfin Project (http://www.pschmidt.it/sharpfin/)
+Source: http://www.pschmidt.it/sharpfin/gpl
 Depends: sharpfin-base
 Section: extras
 Provides: ftpd_init


### PR DESCRIPTION
There was a wrong link to zevv.nl instead of pschmidt.it
