### PR TITLE
sharpfin telnetd links fixed

### DIFF
--- a/src/ipk/sharpfin-telnetd-ipk/files/CONTROL/control
+++ b/src/ipk/sharpfin-telnetd-ipk/files/CONTROL/control
@@ -2,8 +2,8 @@ Package: sharpfin-telnetd
 Priority: optional
 Version:  0.1
 Architecture: arm
-Maintainer: Sharpfin Project (http://www.sharpfin.zevv.nl/)
-Source: http://www.sharpfin.zevv.nl/gpl
+Maintainer: Sharpfin Project (http://www.pschmidt.it/sharpfin/)
+Source: http://www.pschmidt.it/sharpfin/gpl
 Depends: sharpfin-base
 Provides: admin_account user_account telnetd_initscript
 Section: extras


### PR DESCRIPTION
There were a wrong link to zevv.nl instead of pschmidt.it
