### PR TITLE
Sharpfin install makefile adjustments

### DIFF
--- a/src/install/Makefile
+++ b/src/install/Makefile
@@ -22,5 +22,7 @@
 SUBDIRS = sharpfin-base-patch \
 	  sharpfin-test-patch \
 	  sharpfin-uninstall-patch \
+	  sharpfin-lircd-install \
+	  sharpfin-nanddump-install \
 	  sharpfin-www-install
 include ../Rules.mak


### PR DESCRIPTION
Update of the general Makefile to build ALL install packages, these now include also:
- nanddump
- lircd
