### PR TITLE
Sde-install release

### DIFF
--- a/devtools/sdeinstall/Makefile
+++ b/devtools/sdeinstall/Makefile
@@ -1,0 +1,57 @@
+# Sharpfin project
+# Copyright (C) by 2012-01-09 Philipp Schmidt
+#
+# This file is part of the sharpfin project
+#
+# This Library is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This Library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this source files. If not, see
+# <http://www.gnu.org/licenses/>.
+
+# Note: For 7zS.sfx, 7zS2.sfx and/or 7zSD.sfx you may need "7z_extra"
+# (see README)
+
+VERSION := 0.2
+DIST := dist
+DOC  := README
+ZIP := 7z
+SFXTYPE := S
+SFX := 7z$(SFXTYPE).sfx
+
+all: tools.tar sde-install.7z sde-install-$(VERSION).exe
+	mkdir -p $(DIST)
+	$(ZIP) a $(DIST)/SDE-install-$(VERSION).zip sde-install-$(VERSION).exe sde.txt
+
+clean:
+	/bin/rm -f \
+	tools.tar \
+	sde-install.7z \
+	sde-install-*.exe \
+	$(DIST)/SDE-install-*.zip
+
+tools.tar:
+	tar pcfh tools.tar /opt/crosstool
+
+sde-install.7z:
+	$(ZIP) a sde-install.7z run.bat install.sh sde.txt sharpfin.sh tools.tar
+
+sde-install-$(VERSION).exe:
+	@(sfxPath=`which $(ZIP) 2>/dev/null`; \
+	 sfxPath=`dirname "$$sfxPath" 2>/dev/null`; \
+	 sfxPathWin=`cygpath -w "$$sfxPath" 2>/dev/null`; \
+	 if [ -n "$$sfxPathWin" ]; \
+	 then \
+		cmd /C copy /b "$$sfxPathWin\$(SFX)" + config.txt + sde-install.7z sde-install-$(VERSION).exe; \
+	 else \
+		echo "7z.sfx NOT found. Abort"; \
+	 fi)
+

--- a/devtools/sdeinstall/README
+++ b/devtools/sdeinstall/README
@@ -1,0 +1,68 @@
+Version: $Id: readme.txt 6 2012-01-09 10:11:28Z phil $
+
+SDE INSTALL
+===========
+This sde-install.exe is able to setup the toolchain needed to compile and develop
+apps and packages for Sharpfin. Install this package on WIN only (therefore it is
+packaged in a exe) and be sure before installing that cygwin is correctly installed
+at C:/Cygwin.
+
+config.txt
+==========
+This file is used by the Makefile to generate the SFX (SelF Extracting) exe
+file that contains the toolchain. It specifies some settings e.g. the prompts,
+executable scripts etc.
+
+run.bat
+=======
+This file will be launched immediately after the user clicks on the EXE, it
+actually only starts install.sh which does the main job.
+
+install.sh
+==========
+This script file extracts the toolchain to the right location at /opt/crosstool.
+Cywin is needed to install the SDE correctly.
+
+sde.txt
+=======
+This file contains some non development specific explanation about sde-install.
+
+sharpfin.sh
+===========
+Sharpfin.sh will be added to your .profile files such that the environment to use
+the crosstools and this SDE is setup correctly.
+
+sharpfin_sfx.xml
+================
+This file is NOT use by the Makefile but it is the settings file to be used
+with 7-Zip SFX Maker. This tool can be installed (open source) from:
+http://teejee2008.wordpress.com/7-zip-sfx-maker/
+If you like you could add also a ICON with Resource Hacker available at:
+http://delphi.icm.edu.pl/ftp/tools/ResHack.zip
+
+7z.sfx,7zS.sfx,7zS2.sfx and 7zD.sfx
+===================================
+This a different versions of the 7z SFX (Self Extracting) Archive Tool that can be 
+defined with a switch in the Makefile.
+The Makefile assumes that it is located directly in the 7-ZIP Program folder, if NOT
+please set the flag to match your folder.
+7zS.sfx seems to implement all options that we need (and have defined in config.txt),
+instead 7z.sfx (installed by default w/ 7z) lacks of some features.
+You may need to download and install the 7z_extra archive to get these additional
+tools.
+It is available from here:
+http://sourceforge.net/projects/sevenzip/files/7-Zip/[NewestVersion]/7z[NewestVerNum]_extra.7z
+If you need to install it, please copy the content of the folder to
+C:\Program Files\7-Zip\
+and then the sde-install Makefile can find it.
+
+PREREQUISITES
+=============
+You need to have 7z installed and its directory in your $PATH and you also need Cygwin.
+The Makefile also assumes that 7z.sfx is in the same directory as 7z and installed in
+C:\Program Files\7-Zip
+
+UPDATE HISTORY
+==============
+2012-01-09	0.2	Second Alpha Release. Use of new crosstools, Makefile, added to Github
+2008		0.1	Initial Alpha Release.

--- a/devtools/sdeinstall/config.txt
+++ b/devtools/sdeinstall/config.txt
@@ -1,0 +1,11 @@
+﻿;!@Install@!UTF-8!
+Title="Sharpfin SDE setup"
+BeginPrompt="Do you want to install Sharpfin SDE now? This could take a while."
+FinishMessage="All needed files for the Sharpfin SDE were successfully extracted"
+GUIFlags="8"
+OverwriteMode="0"
+ExtractPathText="Select extraction path"
+ExtractPathTitle="Sharpfin SDE setup"
+ExtractCancelText="Abort"
+RunProgram="run.bat"
+;!@InstallEnd@!

--- a/devtools/sdeinstall/install.sh
+++ b/devtools/sdeinstall/install.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Sharpfin project
+# Copyright (C) by 2012-01-09 Philipp Schmidt
+#
+# This file is part of the sharpfin project
+#
+# This Library is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This Library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this source files. If not, see
+# <http://www.gnu.org/licenses/>.
+
+(cd / ; tar xvf - ) < tools.tar
+cp -f sde.txt /opt
+cp -f sharpfin.sh /etc/profile.d
+chmod 555 /opt/sde.txt /etc/profile.d/sharpfin.sh

--- a/devtools/sdeinstall/run.bat
+++ b/devtools/sdeinstall/run.bat
@@ -1,0 +1,24 @@
+REM Sharpfin project
+REM Copyright (C) by 2012-01-09 Philipp Schmidt
+REM
+REM This file is part of the sharpfin project
+REM
+REM This Library is free software: you can redistribute it and/or modify
+REM it under the terms of the GNU General Public License as published by
+REM the Free Software Foundation, either version 3 of the License, or
+REM (at your option) any later version.
+REM
+REM This Library is distributed in the hope that it will be useful,
+REM but WITHOUT ANY WARRANTY; without even the implied warranty of
+REM MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+REM GNU General Public License for more details.
+REM
+REM You should have received a copy of the GNU General Public License
+REM along with this source files. If not, see
+REM <http://www.gnu.org/licenses/>.
+
+%~d0
+cd %~p0
+@echo off
+c:\cygwin\bin\bash.exe install.sh
+notepad c:\cygwin\opt\sde.txt

--- a/devtools/sdeinstall/sde.txt
+++ b/devtools/sdeinstall/sde.txt
@@ -1,0 +1,67 @@
+SDE - Sharpfin Development Environment
+
+
+This suite of programmes is a cross-compiler which has been built
+to run under cygwin on an X86 PC.
+
+PREREQUISITES
+
+You must have Cygwin installed,
+
+CONTENTS
+
+This compiler suite includes the following files:
+
+/opt/crosstool             - crosstool cross-compiler
+                             GCC version 4.1.0
+		             Glibc 2.3.2
+		 
+/etc/profile.d/sharpfin.sh - Sharpfin configuration bash 
+                             startup script
+			     
+USAGE
+
+Start Cygwin via the start-menu "Cygwin Bash Shell". The compiler
+is in the path - it is called 'arm-9tdmi-linux-gnu-gcc'.
+
+It is usual to use Makefiles, and in these, it is usual to refer to
+the compiler as $(CROSS)gcc, and define CROSS in a top level Rules.mak
+file.
+
+
+
+GETTING STARTED
+---------------
+
+
+These notes are correct at the time of going to print, however, always
+check with the sharpfin Wiki for the latest instructions.
+
+
+REPOSITORY
+
+The sharpfin repository can be accessed using SVN.  When in the 
+bash cygwin environment, change to an empty directory, and type
+
+   git clone git://github.com/philsmd/sharpfin.git
+
+svn is part of cygwin, so if it is missing, you will need to go back
+to your cygwin install.
+
+BUILDING
+
+To build the libreciva library and a test application, cd into git/src
+and type:
+
+  make
+  
+You can also type:
+
+  make clean
+  make HARDWARE=devel CROSS=
+  
+To build the ncurses library, which means that applications are built native
+for the local PC using the normal gcc.
+  
+Not all applications will work in this configuration.
+

--- a/devtools/sdeinstall/sharpfin.sh
+++ b/devtools/sdeinstall/sharpfin.sh
@@ -1,0 +1,22 @@
+# Sharpfin project
+# Copyright (C) by 2012-01-09 Philipp Schmidt
+#
+# Crosstool Path Configuration Script
+# Installed by Sharpfin Toolchain (part of the Sharpfin project)
+#
+# This Library is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This Library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this source files. If not, see
+# <http://www.gnu.org/licenses/>.
+
+COMPILERS=`find /opt/crosstool/ -type d -name bin|tr '\n' ':'`
+PATH=$PATH:$COMPILERS

--- a/devtools/sdeinstall/sharpfin_sfx.xml
+++ b/devtools/sdeinstall/sharpfin_sfx.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<!--
+
+Sharpfin project
+Copyright (C) by 2012-01-09 Philipp Schmidt
+
+This file is part of the sharpfin project
+
+This Library is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This Library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this source files. If not, see
+<http://www.gnu.org/licenses/>.
+
+-->
+<Settings>
+  <General>
+    <ExtractMode>Temp</ExtractMode>
+    <HideProgress>False</HideProgress>
+    <SelfDelete>False</SelfDelete>
+    <CompressStub>True</CompressStub>
+    <XPStyles>True</XPStyles>
+    <Overwrite>All</Overwrite>
+    <MessageBegin Show="True">Do you want to install Sharpfin SDE now? This could take a while.</MessageBegin>
+    <MessageCancel Show="False">Are you sure you want to cancel ?</MessageCancel>
+    <MessageFinish Show="True">All needed files for the Sharpfin SDE were successfully extracted</MessageFinish>
+    <TitleText>Sharpfin SDE setup</TitleText>
+    <ExtractPathText>Select extraction path</ExtractPathText>
+    <ExtractCancelText>Abort</ExtractCancelText>
+    <Icon>C:\Program Files\7-Zip SFX Maker\Resources\launcher48.ico</Icon>
+  </General>
+  <Shortcuts />
+  <RunPrograms>
+    <Item>RunProgram="\"%%T\\run.bat\""</Item>
+  </RunPrograms>
+  <EnvVariables />
+</Settings>


### PR DESCRIPTION
Sharpfin Sde install, build the development framework and generate a SFX that is used to setup the development environment (including the crosstool) for Sharpfin
