### PR TITLE
Fixes the build of sharpfin-test-patch, by making relative paths absolute

### DIFF
--- a/src/apps/lcdprint/Makefile
+++ b/src/apps/lcdprint/Makefile
@@ -21,7 +21,7 @@
 
 BIN   	  := lcdprint
 SRC 	  := lcdprint.c
-CFLAGS    += -I../../libreciva/include
-LDFLAGS   += -L../../libreciva -lreciva
+CFLAGS    += -I$(CURDIR)/../../libreciva/include/
+LDFLAGS   += -L$(CURDIR)/../../libreciva -lreciva
 include ../../Rules.mak
 

--- a/src/apps/lcdtest/Makefile
+++ b/src/apps/lcdtest/Makefile
@@ -21,9 +21,9 @@
 
 BIN   	  := lcdtest
 SRC 	  := lcdtest.c
-CFLAGS    += -I$(PWD)/../../libreciva/include
-LDFLAGS   += -L$(PWD)/../../libreciva -lreciva
-VER	:=	"`cat debug/revision.txt | cut -d' ' -f2`"
+CFLAGS    += -I$(CURDIR)/../../libreciva/include
+LDFLAGS   += -L$(CURDIR)/../../libreciva -lreciva
+VER	:= "`cat debug/revision.txt | cut -d' ' -f2`"
 
 include ../../Rules.mak
 

--- a/src/install/sharpfin-test-patch/Makefile
+++ b/src/install/sharpfin-test-patch/Makefile
@@ -30,7 +30,8 @@ sharpfin-test.patch: patch/install-me patch/lcdprint patch/readme.txt patch/lcdp
 	bzip2 patch.tar
 	mv patch.tar.bz2 sharpfin-test.patch
 
-patch/lcdprint: ../../apps/lcdprint/lcdprint
+patch/lcdprint: 
+	(cd ../../apps/lcdprint/;make)
 	cp -f ../../apps/lcdprint/lcdprint patch/lcdprint
 	
 clean:


### PR DESCRIPTION
Solves some problems when building sharpfin-test-patch, relative include/lib paths become absolute in Makefiles
