### PR TITLE
This Sharpfin app is intended to get the bitmap from the LCD screen

### DIFF
--- a/src/apps/lcdshow/Makefile
+++ b/src/apps/lcdshow/Makefile
@@ -1,0 +1,25 @@
+# Sharpfin project
+# Copyright (C) 2012-01-14 Philipp Schmidt
+# 
+# This file is part of the sharpfin project
+#  
+# This Library is free software: you can redistribute it and/or modify 
+# it under the terms of the GNU General Public License as published by 
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# 
+# This Library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#  
+# You should have received a copy of the GNU General Public License
+# along with this source files. If not, see
+# <http://www.gnu.org/licenses/>.
+
+BIN   	  := lcdshow
+SRC 	  := lcdshow.c
+CFLAGS    += -I$(CURDIR)/../../libreciva/include/ -I$(CURDIR)/../../include/reciva/ -I/home/philipp/Desktop/copper.reciva.com/sources/v257-a-756-a-238/lirc/linux_bast/include/
+LDFLAGS   += -L$(CURDIR)/../../libreciva -lreciva
+include ../../Rules.mak
+

--- a/src/apps/lcdshow/README
+++ b/src/apps/lcdshow/README
@@ -1,0 +1,11 @@
+lcdshow
+
+OVERVIEW
+
+This is a simple program, to display the text on the LCD display.  It is
+provided for use in install scripts, to inform the user on the current state
+of display.
+
+
+EXAMPLE
+lcdshow

--- a/src/apps/lcdshow/lcdshow.c
+++ b/src/apps/lcdshow/lcdshow.c
@@ -1,0 +1,62 @@
+/* 
+ * Sharpfin project
+ * Copyright (C) by Steve Clarke and Ico Doornekamp
+ * 2011-11-30 Philipp Schmidt
+ *   Added to github 
+ *
+ * This file is part of the sharpfin project
+ *  
+ * This Library is free software: you can redistribute it and/or modify 
+ * it under the terms of the GNU General Public License as published by 
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This Library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *  
+ * You should have received a copy of the GNU General Public License
+ * along with this source files. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include "lcd.h"
+#include "reciva_lcd.h"
+
+int main(int argc,char**argv) {
+	lcd_handle *h ;
+	lcd_init();
+	lcd_brightness(100) ;
+	h=lcd_framecreate() ;
+	lcd_framesetline(h,1,"TEST") ;
+	lcd_refresh(h) ;
+	int top=0,left=0,width=-1,height=-1;
+	if (argc>1) {
+		top=atoi(argv[1]);
+		if (argc>2) {
+			left=atoi(argv[2]);
+		}
+		if (argc>3) {
+			width=atoi(argv[3]);
+		}
+		if (argc>4) {
+			height=atoi(argv[4]);
+		}
+	}
+	struct bitmap_data*bitmap=lcd_grab_region(top,left,width,height);
+	if (bitmap!=NULL) {
+		printf("top: %i, left: %i, width: %i, height: %i\n",bitmap->top,bitmap->left,bitmap->width,bitmap->height);
+	 	printf("data %p\n",bitmap->data);
+	} else {
+		perror("Bitmap data was NULL");
+		lcd_exit() ;
+		exit(1);
+	} 
+	lcd_exit() ;
+	return 0;
+}

--- a/src/libreciva/include/lcd.h
+++ b/src/libreciva/include/lcd.h
@@ -485,6 +485,11 @@ void lcd_dumpscreen(char *dest, int maxlen) ;
 void lcd_dumpvars(lcd_handle *h, char *str, int n) ;
 
 /**
+ * lcd_grab_region
+ **/
+struct bitmap_data*lcd_grab_region(int top,int left,int width,int height) ;
+
+/**
  * Special Characters
  *
  * These unicode character sequences are interpreted in the

--- a/src/libreciva/src/lcd/lcd_reciva.c
+++ b/src/libreciva/src/lcd/lcd_reciva.c
@@ -598,3 +598,20 @@ char ** lcd_hwgetscreen() {
 enum slcd_e_arrows * lcd_hwgetselrows() {
 	return (enum slcd_e_arrows *) lcd.scr.piArrows ;
 }
+
+/**
+ * lcd_grab_region
+ *
+ * lcd_grab_region function grabs the contents of the screen
+ * buffer 
+ **/
+struct bitmap_data*lcd_grab_region(int top,int left,int width,int height)
+{
+	struct bitmap_data*bitmap=(struct bitmap_data*)malloc(sizeof(struct bitmap_data));
+	bitmap->top=top;
+	bitmap->left=left;
+	bitmap->width=width;
+	bitmap->height=height;
+	lcd_hwdoioctl(IOC_LCD_GRAB_SCREEN_REGION,bitmap); 
+	return bitmap;
+}


### PR DESCRIPTION
Not fully working implementation of lcd_grab_screen()
The idea is to get the bitmap from the LCD driver buffer to e.g. display it in the web interface.... is this possible in this way? Is it supported on all recivas LCD displays?
